### PR TITLE
oops

### DIFF
--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -2,7 +2,7 @@
 namespace OffbeatWP\Helpers;
 
 class ArrayHelper {
-    public static function isAssoc(array $array): bool
+    public static function isAssoc($array): bool
     {
         return is_array($array) && array_keys($array) !== range(0, count($array) - 1);
     }


### PR DESCRIPTION
Fixed isAssoc requiring array type even though it's supposed to check IF it is an array