### PR TITLE
Feature/abstract component changes

### DIFF
--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -120,7 +120,7 @@ abstract class AbstractComponent
 
         $componentSettings = static::settings();
 
-        return isset($componentSettings[$key]) ? $componentSettings[$key] : null;
+        return $componentSettings[$key] ?? null;
     }
 
     public static function getName()

--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -21,6 +21,7 @@ abstract class AbstractComponent
     /** @var Form|null */
     public $form = null;
 
+	/** @return Form|null */
 	static public function form() {
 		return null;
 	}
@@ -163,8 +164,10 @@ abstract class AbstractComponent
     public static function getForm()
     {
 	    $form = static::form();
-	    if(is_null($form)){
-		    if (!method_exists(get_called_class(), 'settings')) return [];
+	    if(is_null($form)) {
+		    if (!method_exists(get_called_class(), 'settings')) {
+                return [];
+            }
 
 		    $settings = static::settings();
 

--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -21,11 +21,6 @@ abstract class AbstractComponent
     /** @var Form|null */
     public $form = null;
 
-	/**
-	 * @return null | Form
-	 * @noinspection PhpMissingReturnTypeInspection
-     * @deprecated This method is public for retro-compatibility, please use getForm() instead.
-     */
 	static public function form() {
 		return null;
 	}

--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -126,31 +126,36 @@ abstract class AbstractComponent
         return (array_key_exists('supports', $settings) && in_array($service, $settings['supports']));
     }
 
-    public static function getSetting($key)
+    /** @return string|string[]|null */
+    public static function getSetting(string $key)
     {
         $settings = static::settings();
 
         return $settings[$key] ?? null;
     }
 
-    public static function getName()
+    public static function getName(): ?string
     {
         return static::getSetting('name');
     }
 
-    public static function getSlug()
+    public static function getSlug(): ?string
     {
         return static::getSetting('slug');
     }
 
-    public static function getDescription()
+    public static function getDescription(): ?string
     {
         return static::getSetting('description');
     }
 
-    public static function getCategory()
+    public static function getCategory(): ?string
     {
         return static::getSetting('category');
+    }
+
+    public static function getIcon(): ?string {
+        return static::getSetting('icon');
     }
 
     public function getViewsDirectory(): string
@@ -165,14 +170,10 @@ abstract class AbstractComponent
         return dirname($classInfo->getFileName());
     }
 
-    public static function getForm()
+    public static function getForm(): Form
     {
 	    $form = static::form();
 	    if(is_null($form)) {
-		    if (!method_exists(get_called_class(), 'settings')) {
-                return [];
-            }
-
 		    $settings = static::settings();
 
 		    if (isset($settings['form'])) {

--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -21,8 +21,12 @@ abstract class AbstractComponent
     /** @var Form|null */
     public $form = null;
 
-	/** @return Form|null */
-	static public function form() {
+	/**
+     * @internal Use getForm instead
+     * @return Form|null
+     */
+	static public function form()
+    {
 		return null;
 	}
 
@@ -39,7 +43,7 @@ abstract class AbstractComponent
      *
      * *string* **icon** - The name of the dash-icon that this setting will use in the editor
      *
-     * *string[]* **supports** - Supported functionality of this component
+     * *string[]* **supports** - Supported functionality of this component. Valid options include 'pagebuilder', 'editor', 'shortcode' and 'widget'.
      * @return string[]|string[][]
      */
 	abstract static function settings();

--- a/src/Components/ComponentRepository.php
+++ b/src/Components/ComponentRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OffbeatWP\Components;
 
 use Exception;
@@ -7,9 +8,7 @@ use OffbeatWP\Layout\Frontend;
 
 class ComponentRepository
 {
-    /**
-     * @var ContextInterface
-     */
+    /** @var ContextInterface|null */
     protected $layoutContext;
 
     public function __construct()
@@ -17,7 +16,7 @@ class ComponentRepository
 
     }
 
-    public function getLayoutContext()
+    public function getLayoutContext(): ?ContextInterface
     {
         return $this->layoutContext;
     }
@@ -28,16 +27,17 @@ class ComponentRepository
      * @param ContextInterface|null $context
      * @return $this
      */
-    public function setLayoutContext(ContextInterface $context = null)
+    public function setLayoutContext(ContextInterface $context = null): ComponentRepository
     {
         $this->layoutContext = $context;
+
         return $this;
     }
 
     public function register($name, $componentClass)
     {
         offbeat('hooks')->doAction('offbeat.component.register', [
-            'name'  => $name,
+            'name' => $name,
             'class' => $componentClass,
         ]);
 
@@ -57,9 +57,9 @@ class ComponentRepository
         $componentSettings = $componentClass::settings();
 
         $widgetSettings = [
-            'id_base'           => $componentSettings['slug'],
-            'name'              => $componentSettings['name'],
-            'component_name'    => $name,
+            'id_base' => $componentSettings['slug'],
+            'name' => $componentSettings['name'],
+            'component_name' => $name,
         ];
 
         $widget = new GenericWidget($widgetSettings, $componentClass);
@@ -85,6 +85,7 @@ class ComponentRepository
         });
     }
 
+    /** @throws Exception */
     public function get($name = null)
     {
         if (is_null($name)) {
@@ -105,7 +106,7 @@ class ComponentRepository
         return offbeat()->container->make($componentClass, ['context' => $this->getLayoutContext()]);
     }
 
-    public function exists($name)
+    public function exists($name): bool
     {
         if (isset($this->components[$name])) {
             return true;

--- a/src/Content/Taxonomy/TaxonomyBuilder.php
+++ b/src/Content/Taxonomy/TaxonomyBuilder.php
@@ -152,9 +152,17 @@ class TaxonomyBuilder
         return $this;
     }
 
-    public function metaBox(callable $metaBoxCallback): TaxonomyBuilder
+    /** @param callable|false $metaBoxCallback */
+    public function metaBox($metaBoxCallback): TaxonomyBuilder
     {
         $this->args['meta_box_cb'] = $metaBoxCallback;
+
+        return $this;
+    }
+
+    public function hideMetaBox(): TaxonomyBuilder
+    {
+        $this->args['meta_box_cb'] = false;
 
         return $this;
     }

--- a/src/Contracts/ISettingsPage.php
+++ b/src/Contracts/ISettingsPage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OffbeatWP\Contracts;
+
+use OffbeatWP\Form\Form;
+
+interface ISettingsPage
+{
+    public function title(): string;
+    public function form(): Form;
+}


### PR DESCRIPTION
This adds more information to the AbstractComponent function. It also includes two logic:

- Any component that extends _abstractcomponent_ must now implement the static **settings** method.
- In an earlier PR I made it so that _metaBox_ can only receive a **callable** as parameter. However, passing **false**'is also valid, so I adjusted this.