### PR TITLE
Feature/post taxonomy type

### DIFF
--- a/src/Content/Taxonomy/TaxonomyBuilder.php
+++ b/src/Content/Taxonomy/TaxonomyBuilder.php
@@ -152,7 +152,12 @@ class TaxonomyBuilder
         return $this;
     }
 
-    /** @param callable|false $metaBoxCallback */
+    /**
+     * Used to render a custom metabox
+     *
+     * __Gutenberg currently does not respect this setting__
+     * @param callable $metaBoxCallback
+     */
     public function metaBox($metaBoxCallback): TaxonomyBuilder
     {
         $this->args['meta_box_cb'] = $metaBoxCallback;
@@ -160,6 +165,11 @@ class TaxonomyBuilder
         return $this;
     }
 
+    /**
+     * Used to disable the metabox
+     *
+     * __Gutenberg currently does not respect this setting__
+     */
     public function hideMetaBox(): TaxonomyBuilder
     {
         $this->args['meta_box_cb'] = false;

--- a/src/Support/Wordpress/PostType.php
+++ b/src/Support/Wordpress/PostType.php
@@ -10,27 +10,17 @@ class PostType
 
     private $postTypeModels = [];
 
-    /**
-     * @param $name
-     * @param $pluralName
-     * @param $singleName
-     * @return PostTypeBuilder
-     */
-    public static function make($name, $pluralName, $singleName)
+    public static function make(string $name, string $pluralName, string $singleName): PostTypeBuilder
     {
         return (new PostTypeBuilder)->make($name, $pluralName, $singleName);
     }
 
-    public function registerPostModel($postType, $modelClass)
+    public function registerPostModel(string $postType, string $modelClass): void
     {
         $this->postTypeModels[$postType] = $modelClass;
     }
 
-    /**
-     * @param string $postType
-     * @return null|string
-     */
-    public function getModelByPostType($postType)
+    public function getModelByPostType(string $postType): ?string
     {
         if (isset($this->postTypeModels[$postType])) {
             return $this->postTypeModels[$postType];
@@ -39,7 +29,7 @@ class PostType
         return self::DEFAULT_POST_MODEL;
     }
 
-    public function getPostTypeByModel($model)
+    public function getPostTypeByModel(string $model): string
     {
         return array_search($model, $this->postTypeModels);
     }

--- a/src/Support/Wordpress/Taxonomy.php
+++ b/src/Support/Wordpress/Taxonomy.php
@@ -14,20 +14,28 @@ class Taxonomy
 
     private $taxonomyModels = [];
 
-    public static function make($name, $postTypes, $pluralName, $singleName)
+    /**
+     * @param string $name
+     * @param string|string[] $postTypes
+     * @param string $pluralName
+     * @param string $singleName
+     * @return TaxonomyBuilder
+     */
+    public static function make(string $name, $postTypes, string $pluralName, string $singleName): TaxonomyBuilder
     {
         return (new TaxonomyBuilder)->make($name, $postTypes, $pluralName, $singleName);
     }
 
-    public function registerTermModel($taxonomy, $modelClass)
+    public function registerTermModel(string $taxonomy, string $modelClass)
     {
         $this->taxonomyModels[$taxonomy] = $modelClass;
     }
 
-    public function getModelByTaxonomy($taxonomy)
+    public function getModelByTaxonomy(string $taxonomy)
     {
-        if (isset($this->taxonomyModels[$taxonomy]))
+        if (isset($this->taxonomyModels[$taxonomy])) {
             return $this->taxonomyModels[$taxonomy];
+        }
 
         return self::DEFAULT_TERM_MODEL;
     }
@@ -39,7 +47,7 @@ class Taxonomy
         return new $model($term);
     }
 
-    public function get($term = null)
+    public function get(?WP_Term $term = null)
     {
         if ($term instanceof WP_Term) {
             return $this->convertWpPostToModel($term);

--- a/src/Support/Wordpress/Taxonomy.php
+++ b/src/Support/Wordpress/Taxonomy.php
@@ -49,7 +49,7 @@ class Taxonomy
 
     /**
      * Get a taxonomy by either the WP_TERM or the taxonomy's ID
-     * Attempts to get the currently queried object if no parameter/null is passed
+     * Attempts to get the currently queried object if no parameter is passed
      * @param WP_Term|int|null $term
      * @return TermModel|null
      */

--- a/src/Support/Wordpress/Taxonomy.php
+++ b/src/Support/Wordpress/Taxonomy.php
@@ -47,7 +47,13 @@ class Taxonomy
         return new $model($term);
     }
 
-    public function get(?WP_Term $term = null)
+    /**
+     * Get a taxonomy by either the WP_TERM or the taxonomy's ID
+     * Attempts to get the currently queried object if no parameter/null is passed
+     * @param WP_Term|int|null $term
+     * @return TermModel|null
+     */
+    public function get($term = null)
     {
         if ($term instanceof WP_Term) {
             return $this->convertWpPostToModel($term);

--- a/src/Views/Wordpress.php
+++ b/src/Views/Wordpress.php
@@ -113,7 +113,7 @@ class Wordpress
         return $attachment[0];
     }
 
-    public function getAttachmentImage(int $attachmentID, $size = 'thumbnail', $classes = ['img-fluid']): string
+    public function getAttachmentImage(?int $attachmentID, $size = 'thumbnail', $classes = ['img-fluid']): string
     {
         return wp_get_attachment_image($attachmentID, $size, false, ['class' => implode(' ', $classes)]);
     }

--- a/src/Views/Wordpress.php
+++ b/src/Views/Wordpress.php
@@ -30,12 +30,12 @@ class Wordpress
         return get_language_attributes();
     }
 
-    public function archiveUrl(string $postType = 'post')
+    public function archiveUrl(?string $postType = 'post')
     {
         return get_post_type_archive_link($postType);
     }
 
-    public function navMenu(array $args = [])
+    public function navMenu(?array $args = [])
     {
         $args['echo'] = false;
 
@@ -57,7 +57,7 @@ class Wordpress
         return get_current_blog_id();
     }
 
-    public function bloginfo($name): string
+    public function bloginfo(?string $name): string
     {
         return get_bloginfo($name, 'display');
     }
@@ -67,14 +67,14 @@ class Wordpress
         body_class($class);
     }
 
-    public function action($action, $args = [])
+    public function action(?string $action, $args = [])
     {
         ob_start();
         do_action($action, $args);
         return ob_get_clean();
     }
 
-    public function shortcode($code): string
+    public function shortcode(?string $code): string
     {
         return do_shortcode($code);
     }
@@ -86,7 +86,7 @@ class Wordpress
         return ob_get_clean();
     }
 
-    public function getAllPostMeta(int $postId = null)
+    public function getAllPostMeta(?int $postId = null)
     {
         if ($postId) {
             return get_post_meta($postId);
@@ -102,7 +102,7 @@ class Wordpress
         return get_post_meta($post->ID);
     }
 
-    public function attachmentUrl(int $attachmentID, $size = 'full')
+    public function attachmentUrl(?int $attachmentID, $size = 'full')
     {
         $attachment = wp_get_attachment_image_src($attachmentID, $size);
 
@@ -118,7 +118,7 @@ class Wordpress
         return wp_get_attachment_image($attachmentID, $size, false, ['class' => implode(' ', $classes)]);
     }
 
-    public function formatDate(string $format, $date, bool $strtotime = false): string
+    public function formatDate(?string $format, $date, bool $strtotime = false): string
     {
         if ($strtotime) {
             $date = strtotime($date);


### PR DESCRIPTION
* Clarify that Gutenberg ignores metabox changes.
* Add params to PostType and Taxonomy
* Make the ID parameter in getAttachmentImage nullable. Right now, it will throw an error if you neglect to wrap the getAttachmentImage in an IF statement that checks if the id exists. This is arguably a good thing, but it can cause page-specific errors on existing sites so I'd rather than risk it.