### PR TITLE
Fix TaxonomyBuilder.php rewrite not behaving correctly

### DIFF
--- a/src/Content/Post/PostTypeBuilder.php
+++ b/src/Content/Post/PostTypeBuilder.php
@@ -38,18 +38,10 @@ class PostTypeBuilder
         return $this;
     }
 
-    /** @param false|array $rewrite Triggers the handling of rewrites for this post type. To prevent rewrites, set to false. */
+    /** @param string[]|bool[]|int[]|bool $rewrite Valid rewrite array keys include: 'slug', 'with_front', 'hierarchical', 'ep_mask' */
     public function rewrite($rewrite): PostTypeBuilder
     {
-        if (!isset($this->postTypeArgs['rewrite'])) {
-            $this->postTypeArgs['rewrite'] = [];
-        }
-
-        if ($rewrite === false) {
-            $this->postTypeArgs['rewrite'] = false;
-        } elseif (is_array($rewrite)) {
-            $this->postTypeArgs['rewrite'] = array_merge($this->postTypeArgs['rewrite'], $rewrite);
-        }
+        $this->postTypeArgs['rewrite'] = $rewrite;
 
         return $this;
     }

--- a/src/Content/Taxonomy/TaxonomyBuilder.php
+++ b/src/Content/Taxonomy/TaxonomyBuilder.php
@@ -32,7 +32,7 @@ class TaxonomyBuilder
         return $this;
     }
 
-    /** @param string[]|bool[]|int[]|bool $rewrite Valid keys include: 'slug', 'with_front', 'hierarchical', 'ep_mask' */
+    /** @param string[]|bool[]|int[]|bool $rewrite Valid rewrite array keys include: 'slug', 'with_front', 'hierarchical', 'ep_mask' */
     public function rewrite($rewrite): TaxonomyBuilder
     {
         $this->args['rewrite'] = $rewrite;

--- a/src/Content/Taxonomy/TaxonomyBuilder.php
+++ b/src/Content/Taxonomy/TaxonomyBuilder.php
@@ -32,18 +32,10 @@ class TaxonomyBuilder
         return $this;
     }
 
-    /** @param array|bool $rewrite */
+    /** @param string[]|bool[]|int[]|bool $rewrite Valid keys include: 'slug', 'with_front', 'hierarchical', 'ep_mask' */
     public function rewrite($rewrite): TaxonomyBuilder
     {
-        if (!isset($this->args['rewrite'])) {
-            $this->args['rewrite'] = [];
-        }
-
-        if ($rewrite === false) {
-            $this->args['rewrite'] = false;
-        } elseif (is_array($rewrite)) {
-            $this->args['rewrite'][] = $rewrite;
-        }
+        $this->args['rewrite'] = $rewrite;
 
         return $this;
     }

--- a/src/Content/Taxonomy/TaxonomyBuilder.php
+++ b/src/Content/Taxonomy/TaxonomyBuilder.php
@@ -35,11 +35,7 @@ class TaxonomyBuilder
     /** @param string[]|bool[]|int[]|bool $rewrite Valid keys include: 'slug', 'with_front', 'hierarchical', 'ep_mask' */
     public function rewrite($rewrite): TaxonomyBuilder
     {
-        if (isset($this->args['rewrite']) && is_array($rewrite)) {
-            $this->args['rewrite'] = array_merge($this->args['rewrite'], $rewrite);
-        } else {
-            $this->args['rewrite'] = $rewrite;
-        }
+        $this->args['rewrite'] = $rewrite;
 
         return $this;
     }

--- a/src/Content/Taxonomy/TaxonomyBuilder.php
+++ b/src/Content/Taxonomy/TaxonomyBuilder.php
@@ -35,7 +35,11 @@ class TaxonomyBuilder
     /** @param string[]|bool[]|int[]|bool $rewrite Valid keys include: 'slug', 'with_front', 'hierarchical', 'ep_mask' */
     public function rewrite($rewrite): TaxonomyBuilder
     {
-        $this->args['rewrite'] = $rewrite;
+        if (isset($this->args['rewrite']) && is_array($rewrite)) {
+            $this->args['rewrite'] = array_merge($this->args['rewrite'], $rewrite);
+        } else {
+            $this->args['rewrite'] = $rewrite;
+        }
 
         return $this;
     }


### PR DESCRIPTION
It attempts to append the $rewrite variable to the current rewrite array, but it needs to be merged.