### PR TITLE
Feature/default POST_TYPE and TAXONOMY

### DIFF
--- a/src/Content/Post/PostModel.php
+++ b/src/Content/Post/PostModel.php
@@ -20,6 +20,7 @@ use WP_Post;
  */
 class PostModel implements PostModelInterface
 {
+    public const POST_TYPE = null;
     private const DEFAULT_POST_STATUS = 'publish';
     private const DEFAULT_COMMENT_STATUS = 'closed';
     private const DEFAULT_PING_STATUS = 'closed';
@@ -517,6 +518,11 @@ class PostModel implements PostModelInterface
     public function belongsToMany($key): BelongsToMany
     {
         return new BelongsToMany($this, $key);
+    }
+
+    protected static function getDefinedType(): ?string
+    {
+        return static::POST_TYPE;
     }
 
     public static function query(): WpQueryBuilderModel

--- a/src/Content/Post/PostModel.php
+++ b/src/Content/Post/PostModel.php
@@ -520,7 +520,7 @@ class PostModel implements PostModelInterface
         return new BelongsToMany($this, $key);
     }
 
-    protected static function getDefinedType(): ?string
+    protected static function getModelType(): ?string
     {
         return static::POST_TYPE;
     }

--- a/src/Content/Post/WpQueryBuilder.php
+++ b/src/Content/Post/WpQueryBuilder.php
@@ -16,7 +16,7 @@ class WpQueryBuilder extends AbstractQueryBuilder
         return $this->get();
     }
 
-    public function postToModel($post)
+    public function postToModel($post): ?PostModel
     {
         return offbeat('post')->convertWpPostToModel($post);
     }

--- a/src/Content/Post/WpQueryBuilderModel.php
+++ b/src/Content/Post/WpQueryBuilderModel.php
@@ -10,7 +10,7 @@ class WpQueryBuilderModel extends WpQueryBuilder
     {
         $this->model = $model;
 
-        $this->wherePostType($model::POST_TYPE ?? 'any');
+        $this->wherePostType($model::POST_TYPE ?: 'any');
 
         $order = null;
         $orderDirection = null;

--- a/src/Content/Post/WpQueryBuilderModel.php
+++ b/src/Content/Post/WpQueryBuilderModel.php
@@ -26,8 +26,7 @@ class WpQueryBuilderModel extends WpQueryBuilder
         $this->order($order, $orderDirection);
     }
 
-    /** @return PostModel */
-    public function postToModel($post)
+    public function postToModel($post): ?PostModel
     {
         return new $this->model($post);
     }

--- a/src/Content/Post/WpQueryBuilderModel.php
+++ b/src/Content/Post/WpQueryBuilderModel.php
@@ -10,7 +10,7 @@ class WpQueryBuilderModel extends WpQueryBuilder
     {
         $this->model = $model;
 
-        $this->wherePostType($model::POST_TYPE);
+        $this->wherePostType($model::POST_TYPE ?? 'any');
 
         $order = null;
         $orderDirection = null;

--- a/src/Content/Taxonomy/TermModel.php
+++ b/src/Content/Taxonomy/TermModel.php
@@ -141,9 +141,9 @@ class TermModel implements TermModelInterface
     {
         global $wp_taxonomies;
 
-        $type = self::getDefinedType();
+        $type = self::getModelType();
 
-        // If no post types defined, get postt ypes where the taxonomy is assigned to
+        // If no post types defined, get post types where the taxonomy is assigned to
         if (empty($postTypes)) {
             $postTypes = isset($wp_taxonomies[$type]) ? $wp_taxonomies[$type]->object_type : ['any'];
         }
@@ -151,7 +151,7 @@ class TermModel implements TermModelInterface
         return (new WpQueryBuilder())->wherePostType($postTypes)->whereTerm($type, $this->getId(), 'term_id');
     }
 
-    protected static function getDefinedType(): ?string
+    protected static function getModelType(): ?string
     {
         return static::TAXONOMY;
     }

--- a/src/Content/Taxonomy/TermModel.php
+++ b/src/Content/Taxonomy/TermModel.php
@@ -12,14 +12,16 @@ use WP_Term;
  */
 class TermModel implements TermModelInterface
 {
+    public const TAXONOMY = null;
+
+    public $wpTerm;
+    public $id;
+
     use FindModelTrait;
     use Macroable {
         Macroable::__call as macroCall;
         Macroable::__callStatic as macroCallStatic;
     }
-
-    public $wpTerm;
-    public $id;
 
     /** @param WP_Term|int|null */
     public function __construct($term)
@@ -139,12 +141,19 @@ class TermModel implements TermModelInterface
     {
         global $wp_taxonomies;
 
-        // If no posttypes defined, get posttypes where the taxonomy is assigned to
+        $type = self::getDefinedType();
+
+        // If no post types defined, get postt ypes where the taxonomy is assigned to
         if (empty($postTypes)) {
-            $postTypes = isset($wp_taxonomies[static::TAXONOMY]) ? $wp_taxonomies[static::TAXONOMY]->object_type : ['any'];
+            $postTypes = isset($wp_taxonomies[$type]) ? $wp_taxonomies[$type]->object_type : ['any'];
         }
 
-        return (new WpQueryBuilder())->wherePostType($postTypes)->whereTerm(static::TAXONOMY, $this->getId(), 'term_id');
+        return (new WpQueryBuilder())->wherePostType($postTypes)->whereTerm($type, $this->getId(), 'term_id');
+    }
+
+    protected static function getDefinedType(): ?string
+    {
+        return static::TAXONOMY;
     }
 
     public static function query(): TermQueryBuilder


### PR DESCRIPTION
This makes it possible to query on the basic PostModel and TermModel.
These will return any PostModel or TermModel regardless of type.

Attempting to query on the offbeat PostModel/TermModel will currently throw a fatal error as it attempts to access a non-existent constant to retrieve the type.