### PR TITLE
Allows the base post model to query every post type.

### DIFF
--- a/src/Content/Post/WpQueryBuilderModel.php
+++ b/src/Content/Post/WpQueryBuilderModel.php
@@ -42,6 +42,10 @@ class WpQueryBuilderModel extends WpQueryBuilder
      */
     public function postToModel($post)
     {
+        if ($this->model === PostModel::class) {
+            return parent::postToModel($post);
+        }
+
         return new $this->model($post);
     }
 }

--- a/src/Content/Post/WpQueryBuilderModel.php
+++ b/src/Content/Post/WpQueryBuilderModel.php
@@ -1,32 +1,45 @@
 <?php
 namespace OffbeatWP\Content\Post;
 
+use OffbeatWP\Exceptions\ModelTypeMismatchException;
+use WP_Post;
+
 class WpQueryBuilderModel extends WpQueryBuilder
 {
     protected $model;
 
-    /** @param class-string<PostModel> $model */
-    public function __construct($model)
+    /**
+     * @throws ModelTypeMismatchException
+     * @param class-string<PostModel> $modelClass
+     */
+    public function __construct(string $modelClass)
     {
-        $this->model = $model;
+        $this->model = $modelClass;
 
-        $this->wherePostType($model::POST_TYPE);
+        if (defined("{$modelClass}::POST_TYPE")) {
+            $this->wherePostType($modelClass::POST_TYPE);
+        } elseif ($modelClass !== PostModel::class) {
+            throw new ModelTypeMismatchException('The POST_TYPE constant must be defined on any model that is not the base PostModel.');
+        }
 
         $order = null;
         $orderDirection = null;
 
-        if (defined("{$model}::ORDER_BY")) {
-            $order = $model::ORDER_BY;
+        if (defined("{$modelClass}::ORDER_BY")) {
+            $order = $modelClass::ORDER_BY;
         }
 
-        if (defined("{$model}::ORDER")) {
-            $orderDirection = $model::ORDER;
+        if (defined("{$modelClass}::ORDER")) {
+            $orderDirection = $modelClass::ORDER;
         }
 
         $this->order($order, $orderDirection);
     }
 
-    /** @return PostModel */
+    /**
+     * @param WP_Post|int|null $post
+     * @return PostModel
+     */
     public function postToModel($post)
     {
         return new $this->model($post);

--- a/src/Content/Post/WpQueryBuilderModel.php
+++ b/src/Content/Post/WpQueryBuilderModel.php
@@ -1,7 +1,7 @@
 <?php
 namespace OffbeatWP\Content\Post;
 
-use OffbeatWP\Exceptions\ModelTypeMismatchException;
+use OffbeatWP\Exceptions\OffbeatInvalidModelException;
 use WP_Post;
 
 class WpQueryBuilderModel extends WpQueryBuilder
@@ -9,7 +9,7 @@ class WpQueryBuilderModel extends WpQueryBuilder
     protected $model;
 
     /**
-     * @throws ModelTypeMismatchException
+     * @throws OffbeatInvalidModelException
      * @param class-string<PostModel> $modelClass
      */
     public function __construct(string $modelClass)
@@ -19,7 +19,7 @@ class WpQueryBuilderModel extends WpQueryBuilder
         if (defined("{$modelClass}::POST_TYPE")) {
             $this->wherePostType($modelClass::POST_TYPE);
         } elseif ($modelClass !== PostModel::class) {
-            throw new ModelTypeMismatchException('The POST_TYPE constant must be defined on any model that is not the base PostModel.');
+            throw new OffbeatInvalidModelException('The POST_TYPE constant must be defined on any model that is not abstract or the base PostModel.');
         }
 
         $order = null;

--- a/src/Exceptions/OffbeatInvalidModelException.php
+++ b/src/Exceptions/OffbeatInvalidModelException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OffbeatWP\Exceptions;
+
+class OffbeatInvalidModelException extends OffbeatException
+{
+
+}


### PR DESCRIPTION
Makes it possible to call "query" on the base PostModel. Doing so will allow you to get all types of posts.  
Before, attempting to query with the base PostModel would just result in a fatal error.

Possible backwards-incompatible changes:  
* Creating an instance of a class that extends PostModel that does not have a POST_TYPE defined will now throw an error. However, even before this change, attempting to query/save such an instance would always result in a fatal error regardless.