### PR TITLE
Feature/change relation method signatures

### DIFF
--- a/src/Content/Post/Relations/BelongsToOneOrMany.php
+++ b/src/Content/Post/Relations/BelongsToOneOrMany.php
@@ -3,17 +3,17 @@ namespace OffbeatWP\Content\Post\Relations;
 
 class BelongsToOneOrMany extends Relation
 {
-    public function associate($ids, $append = true)
+    /**
+     * @param int[] $ids
+     * @param bool $append
+     */
+    public function associate(iterable $ids, bool $append = true)
     {
         if (!$append) {
             $this->dissociateAll();
         }
-        
-        if (is_array($ids)) {
-            $this->makeRelationships($ids, 'reverse');
-        } else {
-            $this->makeRelationship($ids, 'reverse');
-        }
+
+        $this->makeRelationships($ids, 'reverse');
     }
 
     public function dissociate()

--- a/src/Content/Post/Relations/HasOneOrMany.php
+++ b/src/Content/Post/Relations/HasOneOrMany.php
@@ -3,19 +3,20 @@ namespace OffbeatWP\Content\Post\Relations;
 
 class HasOneOrMany extends Relation
 {
-    public function attach($ids, $append = true)
+    /**
+     * @param int[] $ids
+     * @param bool $append
+     */
+    public function attach(iterable $ids, bool $append = true)
     {
         if (!$append) {
             $this->detachAll();
         }
 
-        if (is_array($ids)) {
-            $this->makeRelationships($ids);
-        } else {
-            $this->makeRelationship($ids);
-        }
+        $this->makeRelationships($ids);
     }
 
+    /** @param int $id */
     public function detach($id)
     {
         $this->removeRelationship($id);

--- a/src/Content/Post/Relations/Relation.php
+++ b/src/Content/Post/Relations/Relation.php
@@ -69,12 +69,14 @@ class Relation
         );
     }
 
-    public function makeRelationships(array $ids, ?string $direction = null): void
+    /**
+     * @param int[] $ids
+     * @param string|null $direction
+     */
+    public function makeRelationships(iterable $ids, ?string $direction = null): void
     {
-        if (!empty($ids)) {
-            foreach ($ids as $id) {
-                $this->makeRelationship($id, $direction);
-            }
+        foreach ($ids as $id) {
+            $this->makeRelationship($id, $direction);
         }
     }
 }


### PR DESCRIPTION
The **attach** and **associate** relation methods allow passing a single value rather than an array. However, they will then call **makeRelationships** with this value which attempts to loop over it, so passing a single value will actually never work.

Also changes the makeRelationships type from _array_ to _iterable_ since any iterable should work just fine.