### PR TITLE
Find and FindOrNew will now accept null as parameter

### DIFF
--- a/src/Content/Traits/BaseModelTrait.php
+++ b/src/Content/Traits/BaseModelTrait.php
@@ -7,15 +7,18 @@ use OffbeatWP\Exceptions\OffbeatModelNotFoundException;
 trait BaseModelTrait
 {
     /** @return static|null */
-    public static function find(int $id)
+    public static function find(?int $id)
     {
-        return static::query()->findById($id) ?: null;
+        return ($id) ? static::query()->findById($id) : null;
     }
 
-    /**
-     * @throws OffbeatModelNotFoundException
-     * @return static
-     */
+    /** @return static */
+    public static function findOrNew(?int $id)
+    {
+        return static::find($id) ?: static::create();
+    }
+
+    /** @return static */
     public static function findOrFail(int $id)
     {
         $item = static::find($id);
@@ -24,12 +27,6 @@ trait BaseModelTrait
         }
 
         return $item;
-    }
-
-    /** @return static */
-    public static function findOrNew(int $id)
-    {
-        return static::find($id) ?: static::create();
     }
 
     /** @return static[] */


### PR DESCRIPTION
Additionally Find no longer bothers executing a query if null or 0 is passed as parameter and just return null right away.