### PR TITLE
Remove the QueryBuilder Exception.

### DIFF
--- a/src/Content/Post/WpQueryBuilder.php
+++ b/src/Content/Post/WpQueryBuilder.php
@@ -141,6 +141,13 @@ class WpQueryBuilder
         return $this;
     }
 
+    /**
+     * @param string $taxonomy The taxonomy.
+     * @param string|int|string[]|int[] $terms Taxonomy term(s).
+     * @param string|null $field Select taxonomy term by. Possible values are ‘term_id’, ‘name’, ‘slug’ or ‘term_taxonomy_id’. Default value is ‘term_id’.
+     * @param string|null $operator Operator to test. Possible values are ‘IN’, ‘NOT IN’, ‘AND’, ‘EXISTS’ and ‘NOT EXISTS’. Default value is ‘IN’.
+     * @param bool $includeChildren Whether or not to include children for hierarchical taxonomies. Defaults to true.
+     */
     public function whereTerm(string $taxonomy, $terms = [], ?string $field = 'slug', ?string $operator = 'IN', bool $includeChildren = true): WpQueryBuilder
     {
         if ($field === null) {

--- a/src/Content/Post/WpQueryBuilderModel.php
+++ b/src/Content/Post/WpQueryBuilderModel.php
@@ -18,8 +18,6 @@ class WpQueryBuilderModel extends WpQueryBuilder
 
         if (defined("{$modelClass}::POST_TYPE")) {
             $this->wherePostType($modelClass::POST_TYPE);
-        } elseif ($modelClass !== PostModel::class) {
-            throw new OffbeatInvalidModelException('The POST_TYPE constant must be defined on any model that is not abstract or the base PostModel.');
         }
 
         $order = null;


### PR DESCRIPTION
Would be thrown if POST_TYPE was not defined, but this could legitimately happen if you were to query an Abstract model.