### PR TITLE
Add hasMeta method

### DIFF
--- a/src/Content/Traits/GetMetaTrait.php
+++ b/src/Content/Traits/GetMetaTrait.php
@@ -26,6 +26,16 @@ trait GetMetaTrait
     }
 
     /**
+     * Check if a meta value exists at all.
+     * @return bool True if the meta key exists, regardless of it's value. False if the meta key does not exist.
+     */
+    public function hasMeta(string $key): bool
+    {
+        $metas = $this->getMetas();
+        return ($metas && array_key_exists($key, $metas));
+    }
+
+    /**
      * Retrieve a meta value as a string.<br/>
      * If the meta value does not exist or is falsy, then an <b>empty string</b> is returned.
      */


### PR DESCRIPTION
Currently, there is basically now way to tell the difference between a meta key that doesn't exist and a meta key that exists with the value of **NULL**. In the case of TermModel, is is especially hard to tell since getMeta there null, false and an empty string are treated the same as a meta key not existing.

This method should remedy this.