### PR TITLE
Fix unexpected return value in findById of WpQueryBuilder.php

### DIFF
--- a/src/Content/Post/WpQueryBuilder.php
+++ b/src/Content/Post/WpQueryBuilder.php
@@ -69,6 +69,10 @@ class WpQueryBuilder
 
     public function findById(int $id): ?PostModel
     {
+        if ($id <= 0) {
+            return null;
+        }
+
         $this->queryVars['p'] = $id;
 
         return $this->first();


### PR DESCRIPTION
This change could potentially cause backwards compat issues:
Situations where PostModel::query()->findById(0) is used now always return null.

However, this is probably never done intentionally.