### PR TITLE
GetMetaArray now attempts to unserialize data.

### DIFF
--- a/src/Content/Traits/GetMetaTrait.php
+++ b/src/Content/Traits/GetMetaTrait.php
@@ -104,7 +104,9 @@ trait GetMetaTrait
      */
     public function getMetaArray(string $key): array
     {
-        return (array)$this->getRawMetaValue($key, []);
+        $value = $this->getRawMetaValue($key, []);
+        $value = is_serialized($value) ? unserialize($value, false) : $value;
+        return (array)$value;
     }
 
 


### PR DESCRIPTION
Second parameter is false to ensure it will not unserialise any objects.