### PR TITLE
Feature/find by id can accept null

### DIFF
--- a/src/Content/Post/WpQueryBuilder.php
+++ b/src/Content/Post/WpQueryBuilder.php
@@ -72,7 +72,7 @@ class WpQueryBuilder
 
     public function findById(?int $id): ?PostModel
     {
-        if (!$id || $id <= 0) {
+        if ($id <= 0) {
             return null;
         }
 

--- a/src/Content/Post/WpQueryBuilder.php
+++ b/src/Content/Post/WpQueryBuilder.php
@@ -70,9 +70,9 @@ class WpQueryBuilder
         return $result;
     }
 
-    public function findById(int $id): ?PostModel
+    public function findById(?int $id): ?PostModel
     {
-        if ($id <= 0) {
+        if (!$id || $id <= 0) {
             return null;
         }
 

--- a/src/Content/Taxonomy/TermQueryBuilder.php
+++ b/src/Content/Taxonomy/TermQueryBuilder.php
@@ -101,8 +101,12 @@ class TermQueryBuilder
         return $result;
     }
 
-    public function findById(int $id): ?TermModel
+    public function findById(?int $id): ?TermModel
     {
+        if (!$id || $id < 0) {
+            return null;
+        }
+
         return $this->findBy('id', $id);
     }
 

--- a/src/Content/Taxonomy/TermQueryBuilder.php
+++ b/src/Content/Taxonomy/TermQueryBuilder.php
@@ -103,7 +103,7 @@ class TermQueryBuilder
 
     public function findById(?int $id): ?TermModel
     {
-        if (!$id || $id < 0) {
+        if ($id < 0) {
             return null;
         }
 

--- a/src/Content/User/UserQueryBuilder.php
+++ b/src/Content/User/UserQueryBuilder.php
@@ -55,7 +55,7 @@ class UserQueryBuilder
 
     public function findById(?int $id): ?UserModel
     {
-        if (!$id || $id < 0) {
+        if ($id < 0) {
             return null;
         }
 

--- a/src/Content/User/UserQueryBuilder.php
+++ b/src/Content/User/UserQueryBuilder.php
@@ -53,8 +53,12 @@ class UserQueryBuilder
         return $this->take(1)->first();
     }
 
-    public function findById(int $id): ?UserModel
+    public function findById(?int $id): ?UserModel
     {
+        if (!$id || $id < 0) {
+            return null;
+        }
+
         $this->queryVars['include'] = [$id];
         return $this->first();
     }


### PR DESCRIPTION
Allow the findById methods to accept null.
If any findById method receives a number <1 or null, it will immediately return null without executing the query.