### PR TITLE
Changes the return type of getSlug to not be nullable.

### DIFF
--- a/src/Components/AbstractComponent.php
+++ b/src/Components/AbstractComponent.php
@@ -193,7 +193,7 @@ abstract class AbstractComponent
         return $settings[$key] ?? null;
     }
 
-    public static function getSlug(): ?string
+    public static function getSlug(): string
     {
         return static::getSetting('slug');
     }


### PR DESCRIPTION
A slug must always be defined on a component so getSlug should never be null.