### PR TITLE
Feature/routing 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php-di/php-di": "^6.0",
     "illuminate/support": "^v8.83.18",
-    "symfony/routing": "^4.2",
+    "symfony/routing": "^5.4",
     "symfony/http-foundation": "^4.2",
     "symfony/cache": "^5.0",
     "doctrine/cache": "~1.6",

--- a/src/Foundation/App.php
+++ b/src/Foundation/App.php
@@ -50,7 +50,7 @@ class App
 
         offbeat('hooks')->doAction('offbeat.ready');
 
-        add_filter('wp', [$this, 'findRoute'], 0);
+        add_action('wp', [$this, 'findRoute'], 0);
     }
 
     private function baseBindings(): array


### PR DESCRIPTION
@ChrisRAoW zou je deze PR willen checken? 
Deze PR breidt de RouteManager uit met een prioriteitssysteem waarbij je routes kunnen inschieten op een lage en hoge prioriteit, evenals een fixed prioriteit. De 'addRoute'-method voegt de routes niet gelijk meer toe aan de RouteCollection zodat de prioritering op orde kan worden gebracht voordat ze naar de RouteCollection worden geschoten. 
Zoals je kunt zien wordt de 'addRoutes' verschillende malen aangeroepen. Een alternatief zou kunnen zijn om dit te doen in de App.php:

`
        add_action('wp', [$this, 'addRoutes'], 0);
        add_action('wp', [$this, 'findRoute'], 1);
`

Wil je laten weten wat jij denkt?