### PR TITLE
Feature/routing 5.4 extended

### DIFF
--- a/src/Routes/RoutesManager.php
+++ b/src/Routes/RoutesManager.php
@@ -160,7 +160,10 @@ class RoutesManager
         }
 
         // Symfony will reverse the routes again
-        $routes = array_merge(array_reverse($this->routes[self::PRIORITY_LOW]), $this->routes[self::PRIORITY_HIGH]);
+        $routes = array_merge(
+            array_reverse($this->routes[self::PRIORITY_LOW]),
+            $this->routes[self::PRIORITY_HIGH]
+        );
 
         // adding fixed priority routes
         foreach ($this->routes[self::PRIORITY_FIXED] as $routeData) {
@@ -170,6 +173,7 @@ class RoutesManager
         $this->getRouteCollection()->removeAll();
 
         foreach ($routes as $priority => $route) {
+            /** @var Route $route */
             $this->getRouteCollection()->add($route->getName(), $route, $priority);
         }
 


### PR DESCRIPTION
- Remove some useless comments
- Add type hints to existing properties (with PHPDoc for backwards compat)
- Rename local var $route to $routeObj to avoid conflicts with the parameter that is also named $route
- Small change to AddRoute to require a string param