### PR TITLE
Implemented route priority again and added 'setPriorityMode' to the R…

### DIFF
--- a/src/Foundation/App.php
+++ b/src/Foundation/App.php
@@ -50,7 +50,7 @@ class App
 
         offbeat('hooks')->doAction('offbeat.ready');
 
-        add_action('wp', [$this, 'addRoutes'], 0);
+        add_action('init', [$this, 'addRoutes'], PHP_INT_MAX - 1);
         add_action('wp', [$this, 'findRoute'], 1);
     }
 

--- a/src/Foundation/App.php
+++ b/src/Foundation/App.php
@@ -50,7 +50,8 @@ class App
 
         offbeat('hooks')->doAction('offbeat.ready');
 
-        add_action('wp', [$this, 'findRoute'], 0);
+        add_action('wp', [$this, 'addRoutes'], 0);
+        add_action('wp', [$this, 'findRoute'], 1);
     }
 
     private function baseBindings(): array
@@ -163,6 +164,11 @@ class App
             return $this->config->get($config, $default);
         }
         return $this->config;
+    }
+
+    public function addRoutes()
+    {
+        offbeat('routes')->addRoutes();
     }
 
     public function findRoute(): void

--- a/src/Routes/RouteCollection.php
+++ b/src/Routes/RouteCollection.php
@@ -1,11 +1,14 @@
 <?php
 namespace OffbeatWP\Routes;
 
+use Symfony\Component\Routing\Route as SymfonyRoute;
 use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
 
 class RouteCollection extends SymfonyRouteCollection
 {
-    public function __construct (array $routes = []) {
+    /** @param SymfonyRoute[] $routes */
+    public function __construct (array $routes = [])
+    {
         foreach ($routes as $name => $route) {
             $this->add($name, $route);
         }
@@ -14,9 +17,9 @@ class RouteCollection extends SymfonyRouteCollection
     public function removeAll(): self
     {
         foreach ($this->all() as $route) {
-            /** @var Route $route */
             $this->remove($route->getName());
         }
+
         return $this;
     }
 
@@ -25,6 +28,11 @@ class RouteCollection extends SymfonyRouteCollection
         return $this->where('type', $type);
     }
 
+    /**
+     * @param string $whereKey
+     * @param class-string $whereValue
+     * @return RouteCollection
+     */
     public function where($whereKey, $whereValue): RouteCollection
     {
         $routes = array_filter($this->all(), static function ($route) use ($whereKey, $whereValue) {

--- a/src/Routes/RoutesManager.php
+++ b/src/Routes/RoutesManager.php
@@ -186,7 +186,7 @@ class RoutesManager
         return $this;
     }
 
-    protected function addRoutes(): self
+    public function addRoutes(): self
     {
         if ($this->routesAdded) {
             return $this;

--- a/src/Routes/RoutesService.php
+++ b/src/Routes/RoutesService.php
@@ -12,8 +12,8 @@ class RoutesService extends AbstractService
 
     public function register()
     {
-        add_action('init', [$this, 'loadRoutes'], 10);
-        
+        $this->loadRoutes();
+
         if (!is_admin()) {
             add_action('init', [$this, 'urlRoutePreps'], 15);
         }
@@ -21,11 +21,15 @@ class RoutesService extends AbstractService
 
     public function loadRoutes()
     {
+        offbeat('routes')->setPriorityMode(RoutesManager::PRIORITY_LOW);
+
         $routeFiles = glob($this->app->routesPath() . '/*.php');
 
         foreach ($routeFiles as $routeFile) {
             require $routeFile;
         }
+
+        offbeat('routes')->setPriorityMode(RoutesManager::PRIORITY_HIGH);
     }
 
     public function urlRoutePreps()
@@ -36,11 +40,11 @@ class RoutesService extends AbstractService
 
         add_filter('user_trailingslashit', static function ($url) {
             $urlUnTrailingSlashed = untrailingslashit($url);
-            
+
             if (preg_match('/\.json$/', $urlUnTrailingSlashed)) {
                 return $urlUnTrailingSlashed;
             }
-            
+
             return $url;
         }, 20, 1);
 

--- a/src/Routes/RoutesService.php
+++ b/src/Routes/RoutesService.php
@@ -15,7 +15,7 @@ class RoutesService extends AbstractService
         $this->loadRoutes();
 
         if (!is_admin()) {
-            add_action('init', [$this, 'urlRoutePreps'], 15);
+            add_action('init', [$this, 'urlRoutePreps'], PHP_INT_MAX);
         }
     }
 


### PR DESCRIPTION
Routes defined in the 'routes'-folder are now registered as low-priority routes. These routes are registered in FiFo order.
All other routes are registered in high-priority mode and are LiFo ordered.

Both routes are combined and high priority routes take precedence above low priority routes.

Example:

Route A -> low priority
Route B -> low priority
Route C -> high priority
Route D -> high priority

Resulting order:
Route D
Route C
Route A
Route B

---

In RoutesService, the init-hook to loadRoutes has been removed. Routes will now be loaded directly which ensures backwards compatibility to all use cases. Next to that, the above prioritization ensure routes loaded from the 'routes'-folder are loaded in low-priority mode which allows routes defined in Services to be loaded in high-priority mode (or low/fixed when defined) which ensure they precede the low priority routes.