### PR TITLE
FIX Undefined array key "id"

### DIFF
--- a/src/Content/Post/Relations/Service.php
+++ b/src/Content/Post/Relations/Service.php
@@ -41,7 +41,7 @@ class Service extends AbstractService
             }
         }
 
-        if (is_array($query->query_vars['relationships']['id'])) {
+        if (is_array($query->query_vars['relationships']['id'] ?? null)) {
             $clauses['distinct'] = 'DISTINCT';
         }
 


### PR DESCRIPTION
I can see such warnings in Sentry quite often.

```
Warning: Undefined array key "id"
```

in 

```
        if (is_array($query->query_vars['relationships']['id'])) {
            $clauses['distinct'] = 'DISTINCT';
        }
```
