### PR TITLE
Feature/non existent magic method warning

### DIFF
--- a/src/Content/Post/PostModel.php
+++ b/src/Content/Post/PostModel.php
@@ -99,15 +99,19 @@ class PostModel implements PostModelInterface
             return $this->wpPost->$method;
         }
 
+        $className = class_basename($this);
         $hookValue = offbeat('hooks')->applyFilters('post_attribute', null, $method, $this);
         if ($hookValue !== null) {
+            trigger_error("{$className}::{$method} was accessed through magic");
             return $hookValue;
         }
 
         if (method_exists(WpQueryBuilderModel::class, $method)) {
+            trigger_error("{$className}::{$method} was accessed through magic");
             return static::query()->$method(...$parameters);
         }
 
+        trigger_error("Attempted to access non-existent method {$className}::{$method} through magic", E_USER_WARNING);
         return false;
     }
 
@@ -124,7 +128,7 @@ class PostModel implements PostModelInterface
         }
 
         $className = class_basename($this);
-        trigger_error("Attempted to access non-existent method {$className}::{$methodName} through magic.", E_USER_WARNING);
+        trigger_error("Attempted to access non-existent property {$className}::{$methodName} through magic.", E_USER_WARNING);
         return null;
     }
 

--- a/src/Content/Post/PostModel.php
+++ b/src/Content/Post/PostModel.php
@@ -123,6 +123,8 @@ class PostModel implements PostModelInterface
             return $this->$methodName();
         }
 
+        $className = class_basename($this);
+        trigger_error("Attempted to access non-existent method {$className}::{$methodName} through magic.", E_USER_WARNING);
         return null;
     }
 

--- a/src/Content/Taxonomy/TermModel.php
+++ b/src/Content/Taxonomy/TermModel.php
@@ -60,15 +60,19 @@ class TermModel implements TermModelInterface
             return $this->wpPost->$method;
         }
 
+        $className = class_basename($this);
         $hookValue = offbeat('hooks')->applyFilters('term_attribute', null, $method, $this);
         if ($hookValue !== null) {
+            trigger_error("{$className}::{$method} was accessed through magic");
             return $hookValue;
         }
         
         if (method_exists(TermQueryBuilder::class, $method)) {
+            trigger_error("{$className}::{$method} was accessed through magic");
             return static::query()->$method(...$parameters);
         }
 
+        trigger_error("Attempted to access non-existent method {$className}::{$method} through magic", E_USER_WARNING);
         return false;
     }
 


### PR DESCRIPTION
Attempting to access an attribute or querybuilder with magic methods on Postmodels or Termmodels with magic methods now displays a notice.

Attempting to access a method that does not exist at all on Postmodels or Termmodels will display a warning.

UserModel is unchanged since this already throws an Exception when attempting either of the above.