### PR TITLE
FIXED deprecation about current() and key() types

### DIFF
--- a/src/Content/Post/WpPostsIterator.php
+++ b/src/Content/Post/WpPostsIterator.php
@@ -21,11 +21,13 @@ class WpPostsIterator implements Iterator
         reset($this->items);
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);


### PR DESCRIPTION
FIXED the following PHP compatibility issue about data types:

Return type of OffbeatWP\Content\Post\WpPostsIterator::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice.

The 'mixed' data type is available from PHP8 only, so to keep it compatible with PHP7, I applied #[\ReturnTypeWillChange] as recommended in the message from PHP.