### PR TITLE
Feature/multi user support

### DIFF
--- a/src/Content/User/UserCollection.php
+++ b/src/Content/User/UserCollection.php
@@ -37,7 +37,7 @@ class UserCollection extends OffbeatModelCollection
 
         foreach ($items as $item) {
             $userModel = $this->createValidUserModel($item);
-            if (is_subclass_of($userModel, $modelClass)) {
+            if (is_a($userModel, $modelClass)) {
                 $users[] = $userModel;
             }
         }
@@ -139,7 +139,7 @@ class UserCollection extends OffbeatModelCollection
 
         if (is_int($item) || $item instanceof WP_User) {
             $user = User::get($item, $this->modelClass);
-            return ($user && is_subclass_of($user, $this->modelClass, false)) ? $user : null;
+            return ($user && is_a($user, $this->modelClass)) ? $user : null;
         }
 
         throw new TypeError(gettype($item) . ' cannot be used to generate a UserModel.');

--- a/src/Content/User/UserCollection.php
+++ b/src/Content/User/UserCollection.php
@@ -24,7 +24,7 @@ class UserCollection extends OffbeatModelCollection
 {
     /** @var TModel[] */
     protected $items = [];
-    /** @var class-string<UserModel> */
+    /** @var class-string<TModel> */
     private string $modelClass;
 
     /**
@@ -37,7 +37,7 @@ class UserCollection extends OffbeatModelCollection
 
         foreach ($items as $item) {
             $userModel = $this->createValidUserModel($item);
-            if (is_a($userModel, $modelClass)) {
+            if (is_a($userModel, $this->modelClass)) {
                 $users[] = $userModel;
             }
         }

--- a/src/Content/User/UserCollection.php
+++ b/src/Content/User/UserCollection.php
@@ -24,9 +24,15 @@ class UserCollection extends OffbeatModelCollection
 {
     /** @var UserModel[]|TModel[] */
     protected $items = [];
+    /** @var class-string<UserModel>|'' */
+    private string $modelClass;
 
-    /** @param int[]|WP_User[]|UserModel[] $items */
-    public function __construct(iterable $items = []) {
+    /**
+     * @param int[]|WP_User[]|UserModel[] $items
+     * @param class-string<UserModel>|'' $modelClass
+     */
+    public function __construct(iterable $items = [], string $modelClass = UserModel::class) {
+        $this->modelClass = $modelClass;
         $users = [];
 
         foreach ($items as $item) {

--- a/src/Content/User/UserCollection.php
+++ b/src/Content/User/UserCollection.php
@@ -45,9 +45,7 @@ class UserCollection extends OffbeatModelCollection
      */
     public function getIds(): array
     {
-        return array_map(static function (UserModel $model) {
-            return $model->getId() ?: 0;
-        }, $this->items);
+        return array_map(static fn(UserModel $model) => $model->getId() ?: 0, $this->items);
     }
 
     /** @return UserModel[] */
@@ -60,7 +58,6 @@ class UserCollection extends OffbeatModelCollection
      * Push one or more items onto the end of the user collection.
      * @param int|WP_User|UserModel ...$values
      * @return $this
-     * 
      */
     public function push(...$values)
     {
@@ -137,6 +134,12 @@ class UserCollection extends OffbeatModelCollection
         throw new TypeError(gettype($item) . ' cannot be used to generate a UserModel.');
     }
 
+    /**
+     * Immideatly <b>deletes all users that are part of this collection.</b><br>
+     * Be careful!
+     * @param int|null $reassign
+     * @return void
+     */
     public function deleteAll(?int $reassign = null)
     {
         $this->each(function (UserModel $user) use ($reassign) {

--- a/src/Content/User/UserQueryBuilder.php
+++ b/src/Content/User/UserQueryBuilder.php
@@ -37,7 +37,7 @@ class UserQueryBuilder
 
         $results = $this->getQueryResults();
 
-        return apply_filters('offbeatwp/users/query/get', new UserCollection($results), $this);
+        return apply_filters('offbeatwp/users/query/get', new UserCollection($results, $this->modelClass), $this);
     }
 
     /** @deprecated Use the <b>get</b> method instead. */

--- a/src/Content/User/UserRoleBuilder.php
+++ b/src/Content/User/UserRoleBuilder.php
@@ -25,7 +25,7 @@ final class UserRoleBuilder
      */
     public function model(string $modelClass): UserRoleBuilder
     {
-        if (!is_subclass_of($modelClass, UserModel::class)) {
+        if (!is_a($modelClass, UserModel::class, true)) {
             throw new InvalidArgumentException($modelClass . ' does not extend UserModel.');
         }
 

--- a/src/Support/Wordpress/User.php
+++ b/src/Support/Wordpress/User.php
@@ -33,13 +33,9 @@ class User
         return null;
     }
 
-    /**
-     * @param string $slug
-     * @return void
-     */
     public static function removeUserColumn(string $slug): void
     {
-        add_filter('manage_users_columns', function (array $columnHeaders) use ($slug) {
+        add_filter('manage_users_columns', static function (array $columnHeaders) use ($slug) {
             unset($columnHeaders[$slug]);
             return $columnHeaders;
         });
@@ -56,12 +52,12 @@ class User
      */
     public static function addUserColumn(string $slug, string $header, callable $callback)
     {
-        add_action('manage_users_columns', function ($columnHeaders) use ($slug, $header) {
+        add_action('manage_users_columns', static function ($columnHeaders) use ($slug, $header) {
             $columnHeaders[$slug] = $header;
             return $columnHeaders;
         });
 
-        add_action('manage_users_custom_column', function ($output, $columnName, $userId) use ($slug, $callback) {
+        add_action('manage_users_custom_column', static function ($output, $columnName, $userId) use ($slug, $callback) {
             if ($columnName === $slug) {
                 $output = $callback($output, $columnName, $userId);
             }

--- a/src/Support/Wordpress/User.php
+++ b/src/Support/Wordpress/User.php
@@ -8,12 +8,14 @@ use WP_User;
 class User
 {
     /**
-     * Convert a user to the <b>first</b> matching UserModel or the preferred model, if provided
+     * Convert a user to the <b>first</b> matching UserModel which also matches/extends the preferred model
+     * <b>Beware:</b> It is possible that this method will NOT return a class that extends the prefferred class.<br>
+     * It will return the
      * @param WP_User $user
-     * @param class-string<UserModel>|'' $preferredModel
+     * @param class-string<UserModel> $preferredModel
      * @return UserModel
      */
-    public static function convertWpUserToModel(WP_User $user, string $preferredModel = ''): UserModel
+    public static function convertWpUserToModel(WP_User $user, string $preferredModel = UserModel::class): UserModel
     {
         $modelClass = null;
 
@@ -21,7 +23,7 @@ class User
             $modelRoleClass = UserRole::getModelByUserRole($role);
 
             if ($modelRoleClass) {
-                if (!$preferredModel || $preferredModel === $modelRoleClass) {
+                if (is_subclass_of($modelRoleClass, $preferredModel)) {
                     return new $modelRoleClass($user);
                 }
 
@@ -37,9 +39,9 @@ class User
 
     /**
      * @param int|WP_User $id
-     * @param class-string<UserModel>|'' $preferredModel
+     * @param class-string<UserModel> $preferredModel
      */
-    public static function get($id, string $preferredModel = ''): ?UserModel
+    public static function get($id, string $preferredModel = UserModel::class): ?UserModel
     {
         $user = is_int($id) ? get_userdata($id) : $id;
 

--- a/src/Support/Wordpress/User.php
+++ b/src/Support/Wordpress/User.php
@@ -35,13 +35,16 @@ class User
         return new $modelClass($user);
     }
 
-    /** @param int|WP_User $id */
-    public static function get($id): ?UserModel
+    /**
+     * @param int|WP_User $id
+     * @param class-string<UserModel>|'' $preferredModel
+     */
+    public static function get($id, string $preferredModel = ''): ?UserModel
     {
         $user = is_int($id) ? get_userdata($id) : $id;
 
         if ($user) {
-            return self::convertWpUserToModel($user);
+            return self::convertWpUserToModel($user, $preferredModel);
         }
 
         return null;

--- a/src/Support/Wordpress/User.php
+++ b/src/Support/Wordpress/User.php
@@ -23,7 +23,7 @@ class User
             $modelRoleClass = UserRole::getModelByUserRole($role);
 
             if ($modelRoleClass) {
-                if (is_subclass_of($modelRoleClass, $preferredModel)) {
+                if (is_a($modelRoleClass, $preferredModel, true)) {
                     return new $modelRoleClass($user);
                 }
 

--- a/src/Support/Wordpress/User.php
+++ b/src/Support/Wordpress/User.php
@@ -9,8 +9,7 @@ class User
 {
     /**
      * Convert a user to the <b>first</b> matching UserModel which also matches/extends the preferred model
-     * <b>Beware:</b> It is possible that this method will NOT return a class that extends the prefferred class.<br>
-     * It will return the
+     * <b>Beware:</b> It is possible that this method will NOT always return a class that extends the prefferred class, as it can return the default User Model.
      * @param WP_User $user
      * @param class-string<UserModel> $preferredModel
      * @return UserModel


### PR DESCRIPTION
The User class will not handle users with multiple roles differently.
1) The convertUserToModel method will now accept a second parameter with a preferred model class and user will now return the first class that is/extends this model class.
2) UserQueries should not longer return models that do not match the model on which they were called.