### PR TITLE
Better username validation is UserModel

### DIFF
--- a/src/Content/User/UserModel.php
+++ b/src/Content/User/UserModel.php
@@ -5,6 +5,7 @@ namespace OffbeatWP\Content\User;
 use BadMethodCallException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use OffbeatWP\Content\Traits\BaseModelTrait;
 use OffbeatWP\Content\Traits\GetMetaTrait;
 use OffbeatWP\Exceptions\OffbeatInvalidModelException;
@@ -130,6 +131,19 @@ class UserModel
 
     final public function setLogin(string $userLogin): self
     {
+        if ($userLogin === '' || strlen($userLogin) > 60) {
+            throw new InvalidArgumentException('Username must have 1 ~ 60 characters.');
+        }
+
+        $username = wp_strip_all_tags($userLogin);
+        $username = remove_accents($username);
+        $username = preg_replace('|%([a-fA-F0-9][a-fA-F0-9])|', '', $username);
+        $username = preg_replace('/&.+?;/', '', $username);
+
+        if ($userLogin !== $username) {
+            throw new InvalidArgumentException($userLogin . ' is not a valid username. You could instead use: ' . $username);
+        }
+
         if ($this->wpUser->user_login !== $userLogin) {
             $this->newUserLogin = $userLogin;
         }

--- a/src/Content/User/UserModel.php
+++ b/src/Content/User/UserModel.php
@@ -131,8 +131,12 @@ class UserModel
 
     final public function setLogin(string $userLogin): self
     {
-        if ($userLogin === '' || strlen($userLogin) > 60) {
-            throw new InvalidArgumentException('Username must have 1 ~ 60 characters.');
+        if (!$userLogin) {
+            throw new InvalidArgumentException('Username cannot be empty');
+        }
+
+        if (strlen($userLogin) > 60) {
+            throw new InvalidArgumentException('Username cannot be longer than 60 characters');
         }
 
         $username = wp_strip_all_tags($userLogin);


### PR DESCRIPTION
Most props don't need this since WP will validate them when saving the UserModel.
However, user_login is directly updated in the database. As such, we should probably validate it when we try to set it!