### PR TITLE
Config now correctly defaults to an empty array and acknowledges

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -85,10 +85,15 @@ class Config {
         }
     }
 
+    /**
+     * @param string $key
+     * @param null $default Unused
+     * @return object|resource|\Illuminate\Support\Collection|string|float|int|bool|null|\OffbeatWP\Config\Config
+     */
     public function get(string $key, $default = null)
     {
         $config = $this->config;
-        $return = ArrayHelper::getValueFromDottedKey($key, $config);
+        $return = ArrayHelper::getValueFromDottedKey($key, $config ?: []);
 
         if (is_array($return)) {
             $return = collect($return);
@@ -108,6 +113,7 @@ class Config {
         return $value;
     }
 
+    /** @return mixed[] */
     public function all()
     {
         return $this->config;

--- a/src/Foundation/App.php
+++ b/src/Foundation/App.php
@@ -172,8 +172,8 @@ final class App
 
     /**
      * @param string|null $config
-     * @param mixed $default
-     * @return mixed
+     * @param null $default
+     * @return object|resource|\Illuminate\Support\Collection|string|float|int|bool|null|Config
      */
     public function config(?string $config, $default)
     {

--- a/src/Foundation/helpers.php
+++ b/src/Foundation/helpers.php
@@ -21,8 +21,8 @@ if (!function_exists('offbeat')) {
 if (!function_exists('config')) {
     /**
      * @param string|null $config
-     * @param mixed $default
-     * @return mixed
+     * @param null $default Unused
+     * @return object|resource|\Illuminate\Support\Collection|string|float|int|bool|null
      */
     function config(?string $config = null, $default = null) {
         /** @var App $app */


### PR DESCRIPTION
that the actual $default variable does nothing