### PR TITLE
Update composer.json and deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
   "type": "library",
   "require": {
     "php-di/php-di": "^6.4.0",
+    "illuminate/collections": "^8.0.0",
+    "illuminate/macroable": "^8.0.0",
     "illuminate/support": "^v8.83.27",
     "symfony/routing": "^v5.4.26",
     "symfony/http-foundation": "^v5.4.28",

--- a/src/Content/Post/PostModel.php
+++ b/src/Content/Post/PostModel.php
@@ -468,6 +468,7 @@ class PostModel implements PostModelInterface
     /** @deprecated Use getPostDateTime instead. */
     public function getCreatedAt(): Carbon
     {
+        trigger_error('The getCreatedAt method is deprecated.', E_USER_DEPRECATED);
         $creationDate = get_the_date('Y-m-d H:i:s', $this->wpPost);
 
         if (!$creationDate) {
@@ -480,6 +481,7 @@ class PostModel implements PostModelInterface
     /** @deprecated Use getModifiedDateTime instead. */
     public function getUpdatedAt(): Carbon
     {
+        trigger_error('The getUpdatedAt method is deprecated.', E_USER_DEPRECATED);
         $updateDate = get_the_modified_date('Y-m-d H:i:s', $this->wpPost);
 
         if (!$updateDate) {

--- a/src/Content/Traits/GetMetaTrait.php
+++ b/src/Content/Traits/GetMetaTrait.php
@@ -127,7 +127,7 @@ trait GetMetaTrait
 
         try {
             return WpDateTime::make($datetime);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -147,7 +147,7 @@ trait GetMetaTrait
 
         try {
             return WpDateTimeImmutable::make($datetime);
-        } catch (Exception $e) {
+        } catch (Exception)  {
             return null;
         }
     }
@@ -202,12 +202,14 @@ trait GetMetaTrait
      */
     public function getMetaCarbon(string $key, ?DateTimeZone $tz = null): ?Carbon
     {
+        trigger_error('The getMetaCarbon method is deprecated.', E_USER_DEPRECATED);
         $value = $this->getMeta($key);
 
         if ($value) {
             try {
                 return Carbon::parse($value, $tz);
             } catch (Exception $e) {
+                trigger_error($e->getMessage(), E_USER_WARNING);
                 return null;
             }
         }


### PR DESCRIPTION
- Add illuminate/collections 8 as explicit dependency. (This has always been a peer dependency)
- Add illuminate/macroable 8 as explicit dependency. (This has always been a peer dependency)
- Add some extra notices to the deprecated Carbon methods on models