### PR TITLE
Feature/query builder get lazy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "phpcs": "vendor/bin/php-cs-fixer fix"
   },
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "php-di/php-di": "^7.0.6",
     "illuminate/collections": "^v10.48.11",
     "illuminate/macroable": "^v10.48.11",

--- a/src/Content/Post/PostsCollection.php
+++ b/src/Content/Post/PostsCollection.php
@@ -34,7 +34,7 @@ class PostsCollection extends OffbeatModelCollection
         if ($items instanceof WP_Query || $items instanceof IWpQuerySubstitute) {
             $this->query = $items;
 
-            if (!empty($items->posts)) {
+            if ($items->posts) {
                 foreach ($items->posts as $post) {
                     $postItems[] = offbeat('post')->convertWpPostToModel($post);
                 }

--- a/src/Content/Post/WpQueryBuilder.php
+++ b/src/Content/Post/WpQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace OffbeatWP\Content\Post;
 
+use Generator;
 use InvalidArgumentException;
 use OffbeatWP\Content\Traits\OffbeatQueryTrait;
 use OffbeatWP\Contracts\IWpQuerySubstitute;
@@ -69,6 +70,22 @@ class WpQueryBuilder
         $query = $this->runQuery();
 
         return apply_filters('offbeatwp/posts/query/get', new PostsCollection($query), $this);
+    }
+
+    /**
+     * @return Generator<\OffbeatWP\Content\Post\PostModel>
+     * @phpstan-return TValue
+     */
+    final public function getLazy(): Generator
+    {
+        if (!isset($this->queryVars['no_found_rows'])) {
+            $isPaged = (bool)($this->queryVars['paged'] ?? false);
+            $this->queryVars['no_found_rows'] = !$isPaged;
+        }
+
+        foreach ($this->runQuery()->get_posts() as $post) {
+            yield offbeat('post')->convertWpPostToModel($post);
+        }
     }
 
     /** @return mixed[] */


### PR DESCRIPTION
Updates minimum PHP version to 8.1. This was effectively already the minimum version due to it's dependencies.