### PR TITLE
Undeprecated the getAuthor() function

### DIFF
--- a/src/Content/Post/PostModel.php
+++ b/src/Content/Post/PostModel.php
@@ -372,7 +372,6 @@ class PostModel implements PostModelInterface
     }
 
     /**
-     * @deprecated Consider using getAuthorModel instead
      * @return false|WP_User
      */
     public function getAuthor()


### PR DESCRIPTION
Undeprecated the getAuthor() function because it was referring to a non-existing function getAuthorModel()