### PR TITLE
The TermQueryBuilder::ids() and UserQueryBuilderTermQueryBuilder::ids…

### DIFF
--- a/src/Content/Taxonomy/TermQueryBuilder.php
+++ b/src/Content/Taxonomy/TermQueryBuilder.php
@@ -139,7 +139,7 @@ final class TermQueryBuilder
         return $this;
     }
 
-    /** @return int[] */
+    /** @return positive-int[] */
     public function ids(): array
     {
         $this->queryVars['number'] = $this->queryVars['number'] ?? 0;

--- a/src/Content/User/UserQueryBuilder.php
+++ b/src/Content/User/UserQueryBuilder.php
@@ -196,7 +196,7 @@ final class UserQueryBuilder
         return $this;
     }
 
-    /** @return int[] */
+    /** @return positive-int[] */
     public function ids(): array
     {
         $this->queryVars['fields'] = 'ID';


### PR DESCRIPTION
…() methods now correctly indicates that positive ids are returned.